### PR TITLE
Fix: Long vs Float dtype mismatch in TabrModel

### DIFF
--- a/pytabkit/models/nn_models/tabr.py
+++ b/pytabkit/models/nn_models/tabr.py
@@ -388,7 +388,7 @@ class TabrModel(nn.Module):
         probs = F.softmax(similarities, dim=-1)
         probs = self.dropout(probs)
 
-        context_y_emb = self.label_encoder(candidate_y[context_idx][..., None])
+        context_y_emb = self.label_encoder(candidate_y[context_idx][..., None].float())
         values = context_y_emb + self.T(k[:, None] - context_k)
         context_x = (probs[:, None] @ values).squeeze(1)
         x = x + context_x


### PR DESCRIPTION
Fixed an error in `TabrModel` when `LongTensor` is passed into a Linear layer expecting `FloatTensor`: 

```
RuntimeError: mat1 and mat2 must have the same dtype, but got Long and Float.
```

This occurs in the `forward()` method of `TabrModel` at the line:

```
context_y_emb = self.label_encoder(candidate_y[context_idx][..., None])
```

Here, `candidate_y[...]` is a `LongTensor`, which causes a type mismatch when passed into `nn.Linear`, which expects a `FloatTensor`.