### PR TITLE
Add CatBoost GPU support

### DIFF
--- a/pytabkit/models/alg_interfaces/catboost_interfaces.py
+++ b/pytabkit/models/alg_interfaces/catboost_interfaces.py
@@ -178,6 +178,12 @@ class CatBoostSubSplitInterface(TreeBasedSubSplitInterface):
     # adapted from https://github.com/catboost/benchmarks/blob/master/quality_benchmarks/catboost_experiment.py
     def _preprocess_params(self, params: Dict[str, Any], n_classes: int) -> Dict[str, Any]:
         params = copy.deepcopy(params)
+
+        device = params.pop('device')
+        if device.startswith('cuda:'):
+            params['task_type'] = 'GPU'
+            params['devices'] = device.split(':')[1]
+        
         if n_classes == 0:
             train_metric_name = self.config.get('train_metric_name', 'mse')
             # val_metric_name = self.config.get('val_metric_name', 'rmse')

--- a/pytabkit/models/alg_interfaces/catboost_interfaces.py
+++ b/pytabkit/models/alg_interfaces/catboost_interfaces.py
@@ -179,8 +179,8 @@ class CatBoostSubSplitInterface(TreeBasedSubSplitInterface):
     def _preprocess_params(self, params: Dict[str, Any], n_classes: int) -> Dict[str, Any]:
         params = copy.deepcopy(params)
 
-        device = params.pop('device')
-        if device.startswith('cuda:'):
+        device = params.pop('device', None)
+        if device is not None and device.startswith('cuda:'):
             params['task_type'] = 'GPU'
             params['devices'] = device.split(':')[1]
         


### PR DESCRIPTION
Adds support to run CatBoost on GPU.

Fixes a bug when specifying a gpu `device`, e.g. `gpu`, `cuda`, `cuda:0`, (which is a valid argument to the interfaces `__init__`) as it is not correctly parsed for the catboost model.

This is a bit of a hotfix and I'm sure there are other placed to adapt as well (e.g. there is an `allow_gpu` flag in the `CatBoostSubSplitInterface` that probably should be updated to `True`) but I don't have the best overview over the framework. But maybe this is a good start? If you let me know what to update, I can continue this PR.

See [here](https://catboost.ai/docs/en/features/training-on-gpu) for the relevant CatBoost docs.