### PR TITLE
Use ensure_all_finite from scikit-learn 1.6.0 to avoid FutureWarning

### DIFF
--- a/pytabkit/models/sklearn/sklearn_base.py
+++ b/pytabkit/models/sklearn/sklearn_base.py
@@ -51,7 +51,7 @@ def concat_arrays(x1, x2) -> Any:
 
 
 def check_X_y_wrapper(*args, **kwargs):
-    if Version(sklearn.__version__) >= Version("1.8.0"):
+    if Version(sklearn.__version__) >= Version("1.6.0"):
         if 'force_all_finite' in kwargs:
             kwargs['ensure_all_finite'] = kwargs['force_all_finite']
             del kwargs['force_all_finite']
@@ -64,7 +64,7 @@ def check_X_y_wrapper(*args, **kwargs):
 
 
 def check_array_wrapper(*args, **kwargs):
-    if Version(sklearn.__version__) >= Version("1.8.0"):
+    if Version(sklearn.__version__) >= Version("1.6.0"):
         if 'force_all_finite' in kwargs:
             kwargs['ensure_all_finite'] = kwargs['force_all_finite']
             del kwargs['force_all_finite']


### PR DESCRIPTION
Fixes #41.

`check_X_y_wrapper` / `check_array_wrapper` switched from `force_all_finite` to `ensure_all_finite` only at scikit-learn `>= 1.8.0`, but scikit-learn introduced `ensure_all_finite` in 1.6.0 and keeps `force_all_finite` as a deprecated alias (with a `FutureWarning`) until 1.8. This changes the threshold to `1.6.0` so that scikit-learn 1.6.x / 1.7.x no longer print the warning on every `fit()`.

Verified on scikit-learn 1.6/1.7 (Kaggle image, `TabM_D_Classifier.fit`): the warning disappears and results are unchanged (the argument value is passed through unmodified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)